### PR TITLE
feat: Update h1 font to match site font

### DIFF
--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ body {
 }
 
 .site-content .display-5 {
-    font-family: 'Dancing Script', cursive;
+    font-family: 'Rubik', sans-serif;
     color: #333;
     font-weight: 700;
 }


### PR DESCRIPTION
The font for the h1 element with the class 'display-5' within the 'site-content' class was changed from 'Dancing Script' to 'Rubik' to match the main font of the website.